### PR TITLE
feat: Tier 4 — funnels, scroll depth, server-side API

### DIFF
--- a/cdk/stacks/analytics_stack.py
+++ b/cdk/stacks/analytics_stack.py
@@ -161,6 +161,15 @@ class AnalyticsStack(Stack):
             methods=[apigwv2.HttpMethod.GET],
             integration=query_integration,
         )
+        api.add_routes(
+            path="/api/funnels",
+            methods=[
+                apigwv2.HttpMethod.GET,
+                apigwv2.HttpMethod.POST,
+                apigwv2.HttpMethod.DELETE,
+            ],
+            integration=query_integration,
+        )
 
         # --- S3 bucket for dashboard + tracker script ---
         site_bucket = s3.Bucket(
@@ -279,6 +288,20 @@ class AnalyticsStack(Stack):
                     cache_policy=cloudfront.CachePolicy.CACHING_DISABLED,
                     origin_request_policy=cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
                     allowed_methods=cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
+                ),
+                "/api/funnels": cloudfront.BehaviorOptions(
+                    origin=query_origin,
+                    viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+                    cache_policy=cloudfront.CachePolicy.CACHING_DISABLED,
+                    origin_request_policy=cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+                    allowed_methods=cloudfront.AllowedMethods.ALLOW_ALL,
+                ),
+                "/api/ingest": cloudfront.BehaviorOptions(
+                    origin=collector_origin,
+                    viewer_protocol_policy=cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+                    cache_policy=cloudfront.CachePolicy.CACHING_DISABLED,
+                    origin_request_policy=cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+                    allowed_methods=cloudfront.AllowedMethods.ALLOW_ALL,
                 ),
             },
             domain_names=[domain_name],

--- a/src/collector/index.py
+++ b/src/collector/index.py
@@ -108,6 +108,10 @@ def handler(event, context):
     if method == "OPTIONS":
         return {"statusCode": 200, "headers": CORS_HEADERS, "body": ""}
 
+    path = event.get("rawPath", "")
+    if path.endswith("/ingest"):
+        return _handle_server_event(event)
+
     try:
         body = json.loads(event.get("body", "{}"))
     except (json.JSONDecodeError, TypeError):
@@ -434,6 +438,77 @@ def _get_site_ttl(site_id):
     except Exception:
         _site_ttl_cache[site_id] = None
     return _site_ttl_cache[site_id]
+
+
+def _handle_server_event(event):
+    """Server-side event API — accepts events with API key auth."""
+    try:
+        body = json.loads(event.get("body", "{}"))
+    except (json.JSONDecodeError, TypeError):
+        return _resp(400, "invalid json")
+
+    site_id = (body.get("site_id") or "").strip()
+    api_key = (body.get("api_key") or "").strip()
+    if not site_id or not api_key:
+        return _resp(400, "site_id and api_key required")
+
+    # Validate API key against stored site record
+    if not _validate_api_key(site_id, api_key):
+        return _resp(403, "invalid api_key")
+
+    now = datetime.now(timezone.utc)
+    date_str = now.strftime("%Y-%m-%d")
+
+    site_ttl_days = _get_site_ttl(site_id)
+    ttl = int(now.timestamp()) + (86400 * (site_ttl_days or 395))
+
+    event_name = (body.get("name") or "").strip()[:64]
+    if not event_name:
+        return _resp(400, "name required")
+
+    # Use provided user_id or generate from event data
+    user_id = (body.get("user_id") or "")[:64]
+    visitor_hash = hashlib.sha256(f"server:{user_id}:{site_id}".encode()).hexdigest()[:16] if user_id else uuid.uuid4().hex[:16]
+
+    props = body.get("props") or {}
+    clean_props = {}
+    for k, v in list(props.items())[:10]:
+        clean_props[str(k)[:32]] = str(v)[:128]
+
+    item = {
+        "pk": f"EVENT#{site_id}#{date_str}",
+        "sk": f"{now.isoformat()}#{uuid.uuid4().hex[:8]}",
+        "event_name": event_name,
+        "path": (body.get("url") or "/")[:512],
+        "visitor": visitor_hash,
+        "session": "server",
+        "ttl": ttl,
+    }
+    if clean_props:
+        item["props"] = clean_props
+    table.put_item(Item=item)
+
+    _update_event_summary(site_id, date_str, ttl, event_name, visitor_hash)
+    return _resp(200, "ok")
+
+
+_api_key_cache = {}
+
+
+def _validate_api_key(site_id, api_key):
+    """Check API key against the site record (cached)."""
+    cache_key = f"{site_id}:{api_key}"
+    if cache_key in _api_key_cache:
+        return _api_key_cache[cache_key]
+    try:
+        result = table.get_item(Key={"pk": "SITES", "sk": site_id})
+        item = result.get("Item", {})
+        stored_key = item.get("api_key", "")
+        valid = stored_key and stored_key == api_key
+        _api_key_cache[cache_key] = valid
+    except Exception:
+        _api_key_cache[cache_key] = False
+    return _api_key_cache[cache_key]
 
 
 def _register_site(site_id):

--- a/src/dashboard/src/Dashboard.tsx
+++ b/src/dashboard/src/Dashboard.tsx
@@ -26,6 +26,7 @@ interface SiteInfo {
   id: string;
   domain: string;
   ttl_days?: number;
+  api_key?: string;
 }
 interface DateEntry {
   date: string;
@@ -77,6 +78,22 @@ interface GoalData {
 interface GoalsResponse {
   goals: GoalData[];
   totalVisitors: number;
+}
+interface FunnelStep {
+  label: string;
+  type: string;
+  value: string;
+  visitors: number;
+  dropOff: number;
+}
+interface FunnelData {
+  id: string;
+  name: string;
+  steps: FunnelStep[];
+  conversionRate: number;
+}
+interface FunnelsResponse {
+  funnels: FunnelData[];
 }
 interface PerfData {
   sampleCount: number;
@@ -180,9 +197,15 @@ export default function Dashboard() {
   const [newGoalName, setNewGoalName] = useState("");
   const [newGoalType, setNewGoalType] = useState<"page" | "event">("page");
   const [newGoalValue, setNewGoalValue] = useState("");
-  const [activeTab, setActiveTab] = useState<"overview" | "events" | "realtime" | "performance">("overview");
+  const [activeTab, setActiveTab] = useState<"overview" | "events" | "realtime" | "performance" | "funnels">("overview");
   const [perfData, setPerfData] = useState<PerfData | null>(null);
   const [compareData, setCompareData] = useState<CompareData | null>(null);
+  const [funnelsData, setFunnelsData] = useState<FunnelsResponse | null>(null);
+  const [showFunnelForm, setShowFunnelForm] = useState(false);
+  const [newFunnelName, setNewFunnelName] = useState("");
+  const [newFunnelSteps, setNewFunnelSteps] = useState<{type: string; value: string; label: string}[]>([
+    {type: "page", value: "", label: ""}, {type: "page", value: "", label: ""},
+  ]);
 
   const refreshSites = () =>
     apiFetch("/api/sites")
@@ -245,6 +268,18 @@ export default function Dashboard() {
       .then((data) => setCompareData(data))
       .catch(() => setCompareData(null));
   }, [siteId, days]);
+
+  const refreshFunnels = () => {
+    if (!siteId) return;
+    apiFetch("/api/funnels", { site_id: siteId, days })
+      .then((data) => setFunnelsData(data))
+      .catch(() => {});
+  };
+
+  useEffect(() => {
+    if (!siteId || activeTab !== "funnels") return;
+    refreshFunnels();
+  }, [siteId, days, activeTab]);
 
   useEffect(() => {
     if (!siteId || activeTab !== "performance") return;
@@ -371,6 +406,12 @@ export default function Dashboard() {
               <div key={s.id} className="manage-row">
                 <span className="manage-id">{s.id}</span>
                 <span className="manage-domain">{s.domain}</span>
+                {s.api_key && (
+                  <span className="manage-api-key" title="API key for server-side events">
+                    <code>{s.api_key.slice(0, 8)}...</code>
+                    <button className="btn-table-export" onClick={() => { navigator.clipboard.writeText(s.api_key || ""); }}>Copy</button>
+                  </span>
+                )}
                 <label className="manage-ttl" title="Data retention in days (30-730)">
                   TTL
                   <input
@@ -420,13 +461,13 @@ export default function Dashboard() {
       )}
 
       <div className="tabs">
-        {(["overview", "events", "performance", "realtime"] as const).map((tab) => (
+        {(["overview", "events", "funnels", "performance", "realtime"] as const).map((tab) => (
           <button
             key={tab}
             className={`tab ${activeTab === tab ? "tab-active" : ""}`}
             onClick={() => setActiveTab(tab)}
           >
-            {tab === "overview" ? "Overview" : tab === "events" ? "Events" : tab === "performance" ? "Performance" : "Real-time"}
+            {{overview: "Overview", events: "Events", funnels: "Funnels", performance: "Performance", realtime: "Real-time"}[tab]}
           </button>
         ))}
       </div>
@@ -641,6 +682,79 @@ export default function Dashboard() {
             </div>
           ) : (
             <div className="empty">No goals defined yet</div>
+          )}
+        </div>
+      )}
+
+      {activeTab === "funnels" && (
+        <div className="funnels-panel">
+          <button className="btn-export" onClick={() => setShowFunnelForm(!showFunnelForm)} style={{marginBottom: 12}}>
+            {showFunnelForm ? "Cancel" : "Create Funnel"}
+          </button>
+          {showFunnelForm && (
+            <div className="manage-sites" style={{marginBottom: 16}}>
+              <div className="manage-add" style={{flexDirection: "column", gap: 8}}>
+                <input placeholder="Funnel name" value={newFunnelName} onChange={(e) => setNewFunnelName(e.target.value)} />
+                {newFunnelSteps.map((step, i) => (
+                  <div key={i} style={{display: "flex", gap: 8, alignItems: "center"}}>
+                    <span style={{color: "#64748b", fontSize: 12, minWidth: 50}}>Step {i + 1}</span>
+                    <select value={step.type} onChange={(e) => {
+                      const s = [...newFunnelSteps]; s[i] = {...s[i], type: e.target.value}; setNewFunnelSteps(s);
+                    }} style={{flex: "none", width: "auto", background: "#0f172a", color: "#e2e8f0", border: "1px solid #334155", borderRadius: 6, padding: "6px 8px", fontSize: 13}}>
+                      <option value="page">Page</option>
+                      <option value="event">Event</option>
+                    </select>
+                    <input placeholder={step.type === "page" ? "/signup" : "purchase"} value={step.value}
+                      onChange={(e) => { const s = [...newFunnelSteps]; s[i] = {...s[i], value: e.target.value}; setNewFunnelSteps(s); }} />
+                    <input placeholder="Label (optional)" value={step.label}
+                      onChange={(e) => { const s = [...newFunnelSteps]; s[i] = {...s[i], label: e.target.value}; setNewFunnelSteps(s); }} />
+                    {newFunnelSteps.length > 2 && (
+                      <button className="btn-danger" onClick={() => setNewFunnelSteps(newFunnelSteps.filter((_, j) => j !== i))}>X</button>
+                    )}
+                  </div>
+                ))}
+                <div style={{display: "flex", gap: 8}}>
+                  <button className="btn-export" onClick={() => setNewFunnelSteps([...newFunnelSteps, {type: "page", value: "", label: ""}])}>+ Step</button>
+                  <button className="btn-export" onClick={() => {
+                    if (!newFunnelName.trim() || newFunnelSteps.some(s => !s.value.trim())) return;
+                    apiFetch("/api/funnels", {}, {
+                      method: "POST",
+                      body: { site_id: siteId, name: newFunnelName.trim(), steps: newFunnelSteps.map(s => ({...s, label: s.label || s.value})) },
+                    }).then(() => {
+                      setNewFunnelName(""); setNewFunnelSteps([{type: "page", value: "", label: ""}, {type: "page", value: "", label: ""}]);
+                      setShowFunnelForm(false); refreshFunnels();
+                    }).catch((e) => setError(e.message));
+                  }}>Create</button>
+                </div>
+              </div>
+            </div>
+          )}
+          {funnelsData && funnelsData.funnels.length > 0 ? (
+            funnelsData.funnels.map((f) => (
+              <div key={f.id} className="table-card" style={{marginBottom: 16}}>
+                <div className="table-card-header">
+                  <h3>{f.name} <span style={{fontWeight: 400, color: "#64748b"}}>({f.conversionRate}% conversion)</span></h3>
+                  <button className="btn-danger" onClick={() => {
+                    apiFetch("/api/funnels", {}, { method: "DELETE", body: { site_id: siteId, id: f.id } })
+                      .then(() => refreshFunnels()).catch((e) => setError(e.message));
+                  }}>Delete</button>
+                </div>
+                <div className="funnel-steps">
+                  {f.steps.map((step, i) => (
+                    <div key={i} className="funnel-step">
+                      <div className="funnel-bar" style={{width: `${f.steps[0].visitors > 0 ? (step.visitors / f.steps[0].visitors) * 100 : 0}%`}} />
+                      <div className="funnel-step-content">
+                        <span className="funnel-step-label">{step.label}</span>
+                        <span className="funnel-step-count">{fmt(step.visitors)}</span>
+                        {i > 0 && step.dropOff > 0 && <span className="funnel-drop">-{step.dropOff}%</span>}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="empty">No funnels defined yet. Create one to track multi-step conversion paths.</div>
           )}
         </div>
       )}

--- a/src/dashboard/src/style.css
+++ b/src/dashboard/src/style.css
@@ -326,6 +326,71 @@ thead th {
 }
 .btn-danger:hover { background: #5b1d28; }
 
+.funnel-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.funnel-step {
+  position: relative;
+  padding: 10px 12px;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.funnel-bar {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  background: rgba(14, 165, 233, 0.15);
+  border-radius: 4px;
+  min-width: 2px;
+  transition: width 0.3s ease;
+}
+
+.funnel-step-content {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.funnel-step-label {
+  flex: 1;
+  font-size: 14px;
+}
+
+.funnel-step-count {
+  font-weight: 600;
+  color: #0ea5e9;
+  font-size: 14px;
+}
+
+.funnel-drop {
+  font-size: 12px;
+  color: #ef4444;
+  font-weight: 600;
+  min-width: 45px;
+  text-align: right;
+}
+
+.manage-api-key {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: #64748b;
+}
+
+.manage-api-key code {
+  font-family: monospace;
+  background: #0f172a;
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+
 .change-indicator {
   font-size: 12px;
   font-weight: 600;

--- a/src/query/index.py
+++ b/src/query/index.py
@@ -1,5 +1,6 @@
 import json
 import os
+import secrets
 from datetime import datetime, timedelta, timezone
 from collections import Counter
 
@@ -68,6 +69,18 @@ def handler(event, context):
     if path.endswith("/compare"):
         return _get_compare(params)
 
+    if path.endswith("/funnels"):
+        body = {}
+        try:
+            body = json.loads(event.get("body", "{}") or "{}")
+        except (json.JSONDecodeError, TypeError):
+            pass
+        if method == "POST":
+            return _create_funnel(body)
+        if method == "DELETE":
+            return _delete_funnel(body)
+        return _get_funnels(params)
+
     return _get_stats(params)
 
 
@@ -77,6 +90,7 @@ def _list_sites():
         "id": item["sk"],
         "domain": item.get("domain", ""),
         "ttl_days": int(item.get("ttl_days", 395)),
+        "api_key": item.get("api_key", ""),
     } for item in result.get("Items", [])]
     return _resp(200, {"sites": sites})
 
@@ -86,11 +100,12 @@ def _create_site(body):
     if not site_id or len(site_id) > 64:
         return _resp(400, {"error": "invalid site id"})
     domain = (body.get("domain") or site_id)[:256]
+    api_key = secrets.token_urlsafe(24)
     table.put_item(
-        Item={"pk": "SITES", "sk": site_id, "domain": domain},
+        Item={"pk": "SITES", "sk": site_id, "domain": domain, "api_key": api_key},
         ConditionExpression="attribute_not_exists(pk) AND attribute_not_exists(sk)",
     )
-    return _resp(201, {"id": site_id, "domain": domain})
+    return _resp(201, {"id": site_id, "domain": domain, "api_key": api_key})
 
 
 def _rename_site(body):
@@ -567,6 +582,145 @@ def _query_all(pk):
         )
         items.extend(result.get("Items", []))
     return items
+
+
+def _create_funnel(body):
+    """Create a funnel definition with ordered steps (page paths or event names)."""
+    site_id = (body.get("site_id") or "").strip()
+    name = (body.get("name") or "").strip()
+    steps = body.get("steps") or []
+    if not site_id or not name or len(steps) < 2:
+        return _resp(400, {"error": "site_id, name, and at least 2 steps required"})
+    funnel_id = name.lower().replace(" ", "-")[:32]
+    clean_steps = []
+    for s in steps[:10]:
+        step_type = s.get("type", "page")  # "page" or "event"
+        step_value = (s.get("value") or "")[:128]
+        step_label = (s.get("label") or step_value)[:64]
+        if step_value:
+            clean_steps.append({"type": step_type, "value": step_value, "label": step_label})
+    if len(clean_steps) < 2:
+        return _resp(400, {"error": "at least 2 valid steps required"})
+    table.put_item(Item={
+        "pk": f"FUNNELS#{site_id}",
+        "sk": funnel_id,
+        "name": name,
+        "steps": json.dumps(clean_steps),
+    })
+    return _resp(201, {"id": funnel_id, "name": name, "steps": clean_steps})
+
+
+def _delete_funnel(body):
+    site_id = (body.get("site_id") or "").strip()
+    funnel_id = (body.get("id") or "").strip()
+    if not site_id or not funnel_id:
+        return _resp(400, {"error": "site_id and id required"})
+    table.delete_item(Key={"pk": f"FUNNELS#{site_id}", "sk": funnel_id})
+    return _resp(200, {"deleted": funnel_id})
+
+
+def _get_funnels(params):
+    """List funnels with conversion data for the date range."""
+    site_id = params.get("site_id", "")
+    if not site_id:
+        return _resp(400, {"error": "missing site_id"})
+
+    days = min(int(params.get("days", 7)), 90)
+    end_date = datetime.now(timezone.utc).date()
+    start_date = end_date - timedelta(days=days - 1)
+
+    funnel_items = _query_all(f"FUNNELS#{site_id}")
+    if not funnel_items:
+        return _resp(200, {"funnels": []})
+
+    # Collect raw pageviews and events per visitor
+    visitor_pages: dict = {}  # visitor -> [(timestamp, path)]
+    visitor_events: dict = {}  # visitor -> [(timestamp, event_name)]
+
+    current = start_date
+    while current <= end_date:
+        date_str = current.strftime("%Y-%m-%d")
+        # Raw pageviews
+        pv_items = _query_all(f"{site_id}#{date_str}")
+        for item in pv_items:
+            v = item.get("visitor", "")
+            ts = item["sk"].split("#")[0]
+            path = item.get("path", "")
+            visitor_pages.setdefault(v, []).append((ts, path))
+        # Raw events
+        ev_items = _query_all(f"EVENT#{site_id}#{date_str}")
+        for item in ev_items:
+            v = item.get("visitor", "")
+            ts = item["sk"].split("#")[0]
+            name = item.get("event_name", "")
+            visitor_events.setdefault(v, []).append((ts, name))
+        current += timedelta(days=1)
+
+    # Sort by timestamp
+    for v in visitor_pages:
+        visitor_pages[v].sort()
+    for v in visitor_events:
+        visitor_events[v].sort()
+
+    all_visitors = set(visitor_pages.keys()) | set(visitor_events.keys())
+
+    funnels = []
+    for f in funnel_items:
+        steps = json.loads(f.get("steps", "[]"))
+        step_counts = [0] * len(steps)
+
+        for visitor in all_visitors:
+            pages = visitor_pages.get(visitor, [])
+            events = visitor_events.get(visitor, [])
+            # Check how far this visitor progresses through the funnel (in order)
+            page_idx = 0
+            event_idx = 0
+            for i, step in enumerate(steps):
+                matched = False
+                if step["type"] == "page":
+                    while page_idx < len(pages):
+                        if pages[page_idx][1] == step["value"]:
+                            matched = True
+                            page_idx += 1
+                            break
+                        page_idx += 1
+                elif step["type"] == "event":
+                    while event_idx < len(events):
+                        if events[event_idx][1] == step["value"]:
+                            matched = True
+                            event_idx += 1
+                            break
+                        event_idx += 1
+                if matched:
+                    step_counts[i] += 1
+                else:
+                    break  # Visitor didn't complete this step
+
+        funnel_steps = []
+        for i, step in enumerate(steps):
+            drop_off = 0
+            if i > 0 and step_counts[i - 1] > 0:
+                drop_off = round((1 - step_counts[i] / step_counts[i - 1]) * 100, 1)
+            funnel_steps.append({
+                "label": step.get("label", step["value"]),
+                "type": step["type"],
+                "value": step["value"],
+                "visitors": step_counts[i],
+                "dropOff": drop_off,
+            })
+
+        conv_rate = 0
+        if step_counts[0] > 0:
+            conv_rate = round(step_counts[-1] / step_counts[0] * 100, 1)
+
+        funnels.append({
+            "id": f["sk"],
+            "name": f.get("name", f["sk"]),
+            "steps": funnel_steps,
+            "conversionRate": conv_rate,
+        })
+
+    return _resp(200, {"funnels": funnels})
 
 
 def _resp(status, body):

--- a/src/tracker/script.js
+++ b/src/tracker/script.js
@@ -127,6 +127,37 @@
     } catch (err) {}
   });
 
+  // Scroll depth tracking — fire at 25/50/75/100% thresholds
+  var scrollMarks = {};
+  function trackScroll() {
+    var docHeight = Math.max(
+      document.body.scrollHeight,
+      document.documentElement.scrollHeight
+    );
+    var viewHeight = window.innerHeight;
+    if (docHeight <= viewHeight) return; // no scrolling needed
+    var scrolled = window.scrollY + viewHeight;
+    var pct = Math.round((scrolled / docHeight) * 100);
+    var thresholds = [25, 50, 75, 100];
+    var page = location.pathname;
+    for (var i = 0; i < thresholds.length; i++) {
+      var t = thresholds[i];
+      var key = page + ":" + t;
+      if (pct >= t && !scrollMarks[key]) {
+        scrollMarks[key] = true;
+        trackEvent("scroll", { depth: String(t), page: page });
+      }
+    }
+  }
+  var scrollTimer = null;
+  window.addEventListener("scroll", function () {
+    if (scrollTimer) return;
+    scrollTimer = setTimeout(function () {
+      scrollTimer = null;
+      trackScroll();
+    }, 200);
+  }, { passive: true });
+
   // Heartbeat ping every 30s while page is visible
   var pingInterval = null;
   function startPing() {

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -409,6 +409,45 @@ def test_path_strips_query_string(ddb_table):
     assert pageview["path"] == "/search"
 
 
+def test_server_side_event(ddb_table):
+    """Verify /api/ingest accepts events with API key auth."""
+    collector = load_collector()
+    collector._api_key_cache.clear()
+
+    # Create a site with API key
+    ddb_table.put_item(Item={"pk": "SITES", "sk": "test-site", "domain": "test.com", "api_key": "test-key-123"})
+
+    event = make_event(
+        {"site_id": "test-site", "api_key": "test-key-123", "name": "purchase", "user_id": "user42", "props": {"amount": "99"}},
+        method="POST",
+        path="/api/ingest",
+    )
+    result = collector.handler(event, None)
+    assert result["statusCode"] == 200
+
+    items = ddb_table.scan()["Items"]
+    events = [i for i in items if i["pk"].startswith("EVENT#")]
+    assert len(events) == 1
+    assert events[0]["event_name"] == "purchase"
+    assert events[0]["props"]["amount"] == "99"
+
+
+def test_server_side_event_bad_key(ddb_table):
+    """Verify /api/ingest rejects invalid API key."""
+    collector = load_collector()
+    collector._api_key_cache.clear()
+
+    ddb_table.put_item(Item={"pk": "SITES", "sk": "test-site", "domain": "test.com", "api_key": "real-key"})
+
+    event = make_event(
+        {"site_id": "test-site", "api_key": "wrong-key", "name": "test"},
+        method="POST",
+        path="/api/ingest",
+    )
+    result = collector.handler(event, None)
+    assert result["statusCode"] == 403
+
+
 def test_perf_event(ddb_table):
     """Verify performance metrics are stored as PERF# records."""
     collector = load_collector()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -468,6 +468,92 @@ def test_list_sites_returns_ttl(ddb_table):
     assert body["sites"][0]["ttl_days"] == 120
 
 
+def test_create_and_get_funnels(ddb_table):
+    """Verify funnel CRUD and step-by-step conversion computation."""
+    query = load_query()
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+    # Create a funnel: / -> /pricing -> /signup
+    event = make_event(
+        {"site_id": "test-site", "name": "Signup Flow", "steps": [
+            {"type": "page", "value": "/", "label": "Home"},
+            {"type": "page", "value": "/pricing", "label": "Pricing"},
+            {"type": "page", "value": "/signup", "label": "Signup"},
+        ]},
+        method="POST", path="/api/funnels",
+    )
+    result = query.handler(event, None)
+    assert result["statusCode"] == 201
+    body = json.loads(result["body"])
+    assert body["name"] == "Signup Flow"
+    assert len(body["steps"]) == 3
+
+    # Add raw pageview data — visitor v1 completes all 3, v2 drops at pricing
+    for i, (visitor, path) in enumerate([
+        ("v1", "/"), ("v1", "/pricing"), ("v1", "/signup"),
+        ("v2", "/"), ("v2", "/pricing"),
+        ("v3", "/"),
+    ]):
+        ddb_table.put_item(Item={
+            "pk": f"test-site#{today}",
+            "sk": f"{today}T00:0{i}:00#abc{i}",
+            "path": path,
+            "visitor": visitor,
+            "country": "US",
+            "device": "desktop",
+            "ttl": 9999999999,
+        })
+
+    # Get funnel analysis
+    event = make_event({}, method="GET", path="/api/funnels")
+    event["queryStringParameters"] = {"site_id": "test-site", "days": "1"}
+    result = query.handler(event, None)
+    body = json.loads(result["body"])
+
+    assert len(body["funnels"]) == 1
+    f = body["funnels"][0]
+    assert f["steps"][0]["visitors"] == 3  # 3 visited /
+    assert f["steps"][1]["visitors"] == 2  # 2 visited /pricing
+    assert f["steps"][2]["visitors"] == 1  # 1 visited /signup
+    assert f["conversionRate"] == 33.3  # 1/3
+
+    # Delete funnel
+    event = make_event(
+        {"site_id": "test-site", "id": "signup-flow"},
+        method="DELETE", path="/api/funnels",
+    )
+    result = query.handler(event, None)
+    assert result["statusCode"] == 200
+
+
+def test_create_site_generates_api_key(ddb_table):
+    """Verify POST /api/sites returns an API key."""
+    query = load_query()
+    event = make_event(
+        {"id": "key-site", "domain": "key.example.com"},
+        method="POST", path="/api/sites",
+    )
+    result = query.handler(event, None)
+    body = json.loads(result["body"])
+    assert result["statusCode"] == 201
+    assert len(body["api_key"]) > 16
+
+    # Verify it's in the DB
+    item = ddb_table.get_item(Key={"pk": "SITES", "sk": "key-site"}).get("Item")
+    assert item["api_key"] == body["api_key"]
+
+
+def test_list_sites_returns_api_key(ddb_table):
+    """Verify GET /api/sites includes api_key."""
+    query = load_query()
+    ddb_table.put_item(Item={"pk": "SITES", "sk": "my-site", "domain": "example.com", "api_key": "secret123"})
+
+    event = make_event({}, method="GET", path="/api/sites")
+    result = query.handler(event, None)
+    body = json.loads(result["body"])
+    assert body["sites"][0]["api_key"] == "secret123"
+
+
 def test_get_live_empty(ddb_table):
     query = load_query()
     event = make_event({}, method="GET", path="/api/live")


### PR DESCRIPTION
## Summary
- **Funnel analysis**: Define multi-step conversion funnels (page/event steps), see per-step visitor counts, drop-off rates, and overall conversion. New Funnels dashboard tab with visual step bars.
- **Scroll depth tracking**: Tracker fires events at 25/50/75/100% scroll thresholds (throttled, per-page deduped). Appears in Events tab.
- **Server-side event API**: `POST /api/ingest` with API key auth for backend event ingestion. Keys auto-generated on site creation, shown in manage panel.
- **CloudFront behaviors** for `/api/funnels` and `/api/ingest`
- **49 tests passing** (5 new)

## Test plan
- [x] All 49 tests pass (`pytest -v`)
- [x] Dashboard builds successfully (`vite build`)
- [ ] Deploy and verify Funnels tab
- [ ] Verify scroll depth events appear in Events tab
- [ ] Test server-side event API with curl

🤖 Generated with [Claude Code](https://claude.com/claude-code)